### PR TITLE
Modify RegEx to match URLs without subdomain

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,8 @@ const CLOSED_ZOOM_TABS = {};
 
 function isClosableZoomInviteURL(url) {
     // https://us02web.zoom.us/j/6830992169#success
-    const isZoomInviteURL = url.match(/https:\/\/\S+\.zoom.us\/j\/.+/);
+    // https://zoom.us/j/6830992169#success
+    const isZoomInviteURL = url.match(/https:\/\/(\S+\.)?zoom.us\/j\/.+/);
     const isSuccess = url.endsWith('#success');
 
     return isZoomInviteURL && isSuccess;


### PR DESCRIPTION
Sometimes people send me links without the "us02web" or enterprise subdomain prefix. Modified the regex to make the subdomain optional. 

Tests: https://regexr.com/5b29s
